### PR TITLE
Harden GET /meal test

### DIFF
--- a/week1/homework/test/routes.spec.js
+++ b/week1/homework/test/routes.spec.js
@@ -82,7 +82,10 @@ describe("GET /reservation", () => {
     }
     const response = await request(app).get("/reservation");
     expect(response.statusCode).toBe(200);
-    expect(typeof response.body).toBe("object");
     expect(Array.isArray(response.body)).toBeFalsy();
+    expect(typeof response.body).toBe("object");
+    expect(response.body).toEqual(
+      expect.objectContaining({ id: expect.any(Number) })
+    );
   });
 });

--- a/week1/homework/test/routes.spec.js
+++ b/week1/homework/test/routes.spec.js
@@ -54,8 +54,11 @@ describe("GET /meal", () => {
     }
     const response = await request(app).get("/meal");
     expect(response.statusCode).toBe(200);
-    expect(typeof response.body).toBe("object");
     expect(Array.isArray(response.body)).toBeFalsy();
+    expect(typeof response.body).toBe("object");
+    expect(response.body).toEqual(
+      expect.objectContaining({ id: expect.any(Number) })
+    );
   });
 });
 


### PR DESCRIPTION
An empty response would also pass for this test case.
To improve that scenario, we could assert that the response should contain some movie ID.