### PR TITLE
fix(exercise-template): relocate references of it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,26 +1,27 @@
-
 > Please help us improve and share your feedback! If you find better tutorials or links, please share them by opening a Pull Request.
+
 # NodeJS - Fullstack development
 
 For almost any web application, it is essential to have a backend. The backend is a place where we, the developers, can store our data, communicate with users and let the users communicate with us, do smart things like calculations, data processing etc.
 
 There are many languages for this. We might've heard of Java, C, C++, Go, Python, Ruby, PHP and the list goes on.
 There are two reasons why we at HYF choose Node.JS over others:
+
 1. You already know JavaScript, so it's easier to get started than other languages
 2. Node.js is great for making web APIs because it is asynchronous by nature and thus allows for high input/output. By this we mean that it allows many users to make very light requests at the same time.
 
 In this 3-week module, we will use NodeJS to create and connect both the backend api and serve the frontend html, css and javascript.
 Most of this course will focus on the backend part. Meaning building a webserver that has an api connected to a database.
 
-````Database <--> Webserver````
+`Database <--> Webserver`
 
 ## Planning
 
-| Week | Topic                                                     | Preparation                         | Homework                      | Lesson plan                         |
-| ---- | --------------------------------------------------------- | ----------------------------------- | ----------------------------- | ----------------------------------- |
-| 1.   | HTTP <br> Introduction to node js <br> Simple webserver   | [Preparation](week1/preparation.md) | [Homework](week1/homework/readme.md) | [Lesson plan](week1/lesson-plan.md) |
-| 2.   | Express                                                   | [Preparation](week2/preparation.md) | [Homework](week2/homework/readme.md) | [Lesson plan](week2/lesson-plan.md) |
-| 3.   | Database connection <br> API                              | [Preparation](week3/preparation.md) | [Homework](week3/homework/readme.md) | [Lesson plan](week3/lesson-plan.md) |
+| Week | Topic                                                   | Preparation                         | Homework                             | Lesson plan                         |
+| ---- | ------------------------------------------------------- | ----------------------------------- | ------------------------------------ | ----------------------------------- |
+| 1.   | HTTP <br> Introduction to node js <br> Simple webserver | [Preparation](week1/preparation.md) | [Homework](week1/homework/readme.md) | [Lesson plan](week1/lesson-plan.md) |
+| 2.   | Express                                                 | [Preparation](week2/preparation.md) | [Homework](week2/homework/readme.md) | [Lesson plan](week2/lesson-plan.md) |
+| 3.   | Database connection <br> API                            | [Preparation](week3/preparation.md) | [Homework](week3/homework/readme.md) | [Lesson plan](week3/lesson-plan.md) |
 
 ## Pre-requisites
 
@@ -38,3 +39,12 @@ We will build on knowledge from the following HYF (sub)modules. If we feel we ha
 - Using `express` to make a RESTful API
 - Using `mysql` to connect the API to the backend
 - Postman
+
+## Extra practice
+
+If you have the time, you could follow another simple set of exercises to get a better grasp of Node.js and some more practice.
+Feel free to bring any questions from this to the class or raise them on slack!
+
+Clone the repository that holds the exercises templates: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.git
+
+See each week's `readme.md` and follow the instructions to setup the server.

--- a/week1/lesson-plan.md
+++ b/week1/lesson-plan.md
@@ -14,14 +14,12 @@ Remember to add the code you wrote in the class to the relevant class branch's c
 
 To find examples of what teachers have taught before go to the class branches in the classwork folder, Fx [class 07](https://github.com/HackYourFuture-CPH/JavaScript/tree/class07/JavaScript1/Week1/classwork)
 
-Repository for the in-class exercises templates: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template
-
 If you find anything that could be improved then please create a pull request! We welcome changes, so please get involved if you have any ideas!!!
 
 ---
 
-
 # Introduction
+
 In the first week of the module we will focus on a general introduction starting from what happens when you open a webpage in the browser, an introduction to the underlying protocol HTTP (the roads of the internet) as well as an introduction to what can be build with node.
 
 # Learning goals
@@ -36,9 +34,9 @@ In the first week of the module we will focus on a general introduction starting
     - Sends request
     - Receives response
   - [ ] HTTP server
-     - Listen for requests
-     - Responds with data     
-   - https://websniffer.cc/
+    - Listen for requests
+    - Responds with data
+  - https://websniffer.cc/
 - [ ] [Introduction to node js](#What-is-Nodejs)
   - [ ] [What is node and why node?](https://www.youtube.com/watch?v=pU9Q6oiQNd0)
   - [ ] V8 vs the browser that runs js?
@@ -59,10 +57,8 @@ In the first week of the module we will focus on a general introduction starting
       - package.json
     - [.gitignore](https://github.com/HackYourFuture-CPH/teacher-live-coding/blob/main/.gitignore)
   - [ ] Nodemon
-  - [ ] Express - Simple `GET` requests, focus on usage
-     -  Play around with Express - Focus on usage!
-        - [Live coding](https://github.com/HackYourFuture-CPH/teacher-live-coding/)
-        - [Exercise](https://github.com/HackYourFuture-CPH/Nodejs-exercise-template/tree/main/week1)
+  - [ ] Express - Simple `GET` requests
+
 ## What is backend?
 
 In software development, we separate the user experience and utility (the `frontend`) from the code that actually makes it work (the `backend`). The real world contains many examples of this division: take for example an [ATM](../images/atm.jpg). What you can interact with it (press a button or insert a card), you are dealing with the `user interface`; which is the end result of frontend code. However, everything that's needed to make it work like that is found within the device: this is the hardware and software needed to make it work the way it does.
@@ -74,6 +70,7 @@ In web development the term backend can be boiled down to 3 components:
 - An `application`: software that communicates between the server, database and frontend. It contains code that allows it to interact with and manipulate the server, database and other type of software services.
 
 For more information, read:
+
 - [Basics of backend development](https://www.upwork.com/hiring/development/a-beginners-guide-to-back-end-development/)
 - [Getting started with backend development](https://codeburst.io/getting-started-with-backend-development-bfd8299e22e8)
 
@@ -141,7 +138,6 @@ Look into the following resources to increase your understanding:
 
 - [@NoerGitKat](https://www.github.com/NoerGitKat)
 
-
 ## Flipped classroom videos
 
 [Flipped classroom videos](https://github.com/HackYourFuture-CPH/node.js/blob/main/week1/preparation.md#flipped-classroom-videos)
@@ -150,12 +146,11 @@ Look into the following resources to increase your understanding:
 
 ### Created module
 
-Go to the `teacher-live-coding` [project repository](https://github.com/HackYourFuture-CPH/teacher-live-coding), `npm install` and run using `nodemon ./src/backend/created-module.js`. Try and implement this functionality from the bottom while explaining. 
+Go to the `teacher-live-coding` [project repository](https://github.com/HackYourFuture-CPH/teacher-live-coding), `npm install` and run using `nodemon ./src/backend/created-module.js`. Try and implement this functionality from the bottom while explaining.
 
 ### Building a simple http webserver
 
 Go to the `teacher-live-coding` [project repository](https://github.com/HackYourFuture-CPH/teacher-live-coding), run using `nodemon ./src/backend/simple-webserver.js`. Try and implement this functionality from the bottom while explaining.
-
 
 # Exercises
 

--- a/week1/preparation.md
+++ b/week1/preparation.md
@@ -8,8 +8,8 @@
       - `node -v`
       - `npm -v`
       - In either case you should see the version of `node` or `npm` installed.
-      
- ## Understanding the basics of NodeJS
+
+## Understanding the basics of NodeJS
 
 - Client server model: https://www.youtube.com/watch?v=L5BlpPU_muY (6 min)
 - HTTP and HTML: https://www.youtube.com/watch?v=1K64fWX5z4U (7 min)
@@ -25,48 +25,51 @@ Try to formulate an answer to the question:
 ## Flipped classroom videos
 
 ### Teacher Live Coding Videos - https://github.com/HackYourFuture-CPH/teacher-live-coding
+
 - [What happens when you open a webpage - Class 1](https://youtu.be/wdj2LrpKSdg)
 - [What is node js and how to use it - Class 1](https://youtu.be/gTa5R1PHIiY)
 - [Node js project structure - Class1](https://youtu.be/CUY20f-KBxE)
 - [Creating a simple Express webserver in Node js and creating your own modules - Class 1](https://youtu.be/R-dl4-VnZYA)
 
-## Get ready for in-class exercises!
-Clone the repository that holds the exercises templates for the whole module: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.git
-
-See week1 `readme.md` and follow the instructions to setup the server. 
-<br>
-<hr>
-
 ## Extras
 
 ### **Good resources for learning node**
+
 [8 hours intro to NodeJS](https://www.youtube.com/watch?v=Oe421EPjeBE)
+
 ### **The REPL**
+
 There are many ways to interact with Node. We can start the environment up in a REPL, we can start it up with a file, we can start it inside a docker container.
-After installing NodeJS on your machine, you will have access to the environment by typing ````node```` in the terminal. This will drop you into the node REPL (Read Evaluate Print Loop).
-````
+After installing NodeJS on your machine, you will have access to the environment by typing `node` in the terminal. This will drop you into the node REPL (Read Evaluate Print Loop).
+
+```
 Welcome to Node.js v15.14.0
 Type “.help” for more information.
 >
-````
+```
+
 In here you will have access to the javascript language. There are limitations, which depends on the version number of Node. The further it progresses in time, the more features will be included.
 
-
 ### **Feeding the REPL files**
+
 You can also feed node files to evaluate and this is where node becomes such a powerful tool for any developer, especially frontend developers.
 
 ### **Creating an NPM project with a script that starts the application**
+
 http://ajmalsiddiqui.me/blog/introduction-to-npm-scripts/
 
 ### **As a Webserver**
+
 - Can serve HTTP responses to HTTP requests.
 - Is most often used together with the REST principle.
 - The REST principle is an architecture for organising resources.
 
 ### **Security and authentication**
+
 In many cases we don’t want the web server to just serve information, some of this might be privilege to a user. It can be the responsibility of the web server to also check that the requests it receives has the right authentication required.
 
 ### **Database interaction**
+
 The web server rarely has any information or data build into it. It relies on external system build specifically for that purpose and acts as a proxy between the database and the requester. (However node is a general purpose programming language, so it can indeed also be used to write a database system (https://dzone.com/articles/building-a-database-written-in-nodejs-from-the-gro).
 
 ### **Tests**

--- a/week2/lesson-plan.md
+++ b/week2/lesson-plan.md
@@ -14,8 +14,6 @@ Remember to add the code you wrote in the class to the relevant class branch's c
 
 To find examples of what teachers have taught before go to the class branches in the classwork folder, Fx [class 07](https://github.com/HackYourFuture-CPH/JavaScript/tree/class07/JavaScript1/Week1/classwork)
 
-Repository for the in-class exercises templates: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template
-
 If you find anything that could be improved then please create a pull request! We welcome changes, so please get involved if you have any ideas!!!
 
 ---
@@ -68,12 +66,11 @@ Run `nodemon ./src/backend/route-order.js`. Try and implement this functionality
 
 Run using `nodemon ./src/backend/middleware.js`. Try and implement this functionality from the bottom while explaining.
 
-
 # Exercises
 
 1. [Server](./exercises/01-server.md): Setup project
 1. [DB schema](./exercises/02-schema.md): Setup MySQL database schema
 1. [API](./exercises/03-api.md): Snippets API exercises
-    - [POST endpoint](./exercises/04-post-endpoint.md)
-    - [GET endpoints](./exercises/05-get-endpoints.md)
-    - [Authentication](./exercises/06-auth.md)
+   - [POST endpoint](./exercises/04-post-endpoint.md)
+   - [GET endpoints](./exercises/05-get-endpoints.md)
+   - [Authentication](./exercises/06-auth.md)

--- a/week2/preparation.md
+++ b/week2/preparation.md
@@ -5,13 +5,9 @@
 - https://fullstackopen.com/en/part3/node_js_and_express#express until but without the `nodemon` part! (10 min)
 
 ## Flipped classroom videos
+
 - [Nodejs express part 1 - Class 2](https://youtu.be/4HIq70RzDTY)
 - [Nodejs express part 2 - Class 2](https://youtu.be/-J1pd4LgjUo)
 - [Nodejs express query parameters and params - Class 2](https://youtu.be/_H-bP10Fmaw)
 - [Nodejs express middleware - Class 2](https://youtu.be/ZcwmyYGzBnk)
 - [Working with Postman - Class 2](https://youtu.be/zNeOUJPxw2s)
-
-## Get ready for in-class exercises!
-Clone, if you have not already, the repository that holds the exercises templates for the whole module: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.git
-
-See week2 `readme.md` and follow the instructions to setup the server. 

--- a/week3/lesson-plan.md
+++ b/week3/lesson-plan.md
@@ -14,8 +14,6 @@ Remember to add the code you wrote in the class to the relevant class branch's c
 
 To find examples of what teachers have taught before go to the class branches in the classwork folder, Fx [class 07](https://github.com/HackYourFuture-CPH/JavaScript/tree/class07/JavaScript1/Week1/classwork)
 
-Repository for the in-class exercises templates: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template
-
 If you find anything that could be improved then please create a pull request! We welcome changes, so please get involved if you have any ideas!!!
 
 ---
@@ -46,13 +44,13 @@ If you find anything that could be improved then please create a pull request! W
 - Go to the `teacher-live-coding` [repo](https://github.com/HackYourFuture-CPH/teacher-live-coding), to the relevant folder
 - Copy the `.env.example` and rename the copied file to `.env`
 - Run `npm install`
-- Start the application by running  `nodemon ./src/backend/phonebook-database-queries.js`
+- Start the application by running `nodemon ./src/backend/phonebook-database-queries.js`
 
 Try and implement this functionality from the bottom while explaining.
 
 ### Phonebook api
 
-Start the application by running  `nodemon ./src/backend/create-an-api.js`.
+Start the application by running `nodemon ./src/backend/create-an-api.js`.
 
 The following two routes have been created, get help by the students to create some of the other routes.
 
@@ -64,14 +62,7 @@ The following two routes have been created, get help by the students to create s
 | `api/contacts/{id}` | PUT    | Updates the contact by `id` | `PUT api/contacts/2` |
 | `api/contacts/{id}` | DELETE | Deletes the contact by `id` | `DELETE contacts/2`  |
 
-
-# Exercises
-
-The template for in-class exercises is in this repository: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.
-
-Every student should have it cloned locally and setup according to the instructions in the repository.
-See https://github.com/HackYourFuture-CPH/Nodejs-exercise-template/tree/main/week3 for the instructions and requirements.
-
-
+<br/>
+<hr/><hr/>
 
 Thank you very much for teaching NodeJS. Please don't hesitate to give feedback by clicking [here](https://forms.gle/sAuVhsTmJ1qSmjgJ6) (teachers and teacher assistants). For homework reviewers, please access the survey [here](https://forms.gle/nVbX9ShusF2a5Aa87).

--- a/week3/preparation.md
+++ b/week3/preparation.md
@@ -3,14 +3,10 @@
 - https://www.youtube.com/watch?v=QNw9q4YXR4E (15 min)
 - https://fullstackopen.com/en/part3/node_js_and_express#rest until but without `The Visual Studio Code REST client` (15 min)
 - https://jsonplaceholder.typicode.com/ - Good example of an api (5 min)
-
+  s
 
 ## Flipped classroom videos
+
 - [Connecting nodejs to a database using Knex part 1 - Class 3](https://youtu.be/W5xFbiAl4bo)
 - [Connecting nodejs to a database using Knex part 2 - Class 3](https://youtu.be/cacTSGU7Hrc)
 - [Creating an api using nodejs and express - Class 3](https://youtu.be/i-BUdUMz6Zk)
-
-## Get ready for in-class exercises!
-Clone, if you have not already, the repository that holds the exercises templates for the whole module: https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.git
-
-See week3 `readme.md` and follow the instructions to setup the server. 


### PR DESCRIPTION
It seems like the the part with the exercise templates, intended as class exercises, was overlooked in the latest update. 
https://github.com/HackYourFuture-CPH/Nodejs-exercise-template.git
It creates some confusion about what the scope of preparation is and what are the class exercises. 
As Orhan has prepared class exercises for week1 and week2, while week3 uses yet another set, I removed this `Nodejs-exercise-template.git` thing from prep and lesson plans and just mentioned it as extra project in the general repo Readme.md.