### PR TITLE
Update node curriculum to use modern import/export for JS modules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ We will build on knowledge from the following HYF (sub)modules. If we feel we ha
 
 - What is Node.js?
 - Using Node Package Manager (NPM)
-- Using `require` to include modules
+- Using `import` to include modules
 - Using `express` to make a RESTful API
 - Using `mysql` to connect the API to the backend
 - Postman

--- a/week1/exercises/01-server.md
+++ b/week1/exercises/01-server.md
@@ -15,6 +15,7 @@ Initialize and install:
     $ npm install express
 
 Make sure you see a `package.json`.
+Make sure you have `"type": "module"` in your `package.json`.
 Do you see `express` somewhere in `package.json`?
 Also make sure you see the `node_modules` folder.
 
@@ -23,7 +24,7 @@ Also make sure you see the `node_modules` folder.
 Create a file called `app.js`:
 
 ```js
-const express = require('express')
+import express from 'express'
 const app = express()
 const port = 3000
 

--- a/week1/exercises/02-database.md
+++ b/week1/exercises/02-database.md
@@ -13,7 +13,8 @@ In `app.js` we can now establish the database connection.
 Add the following to the top of `app.js`:
 
 ```js
-const knex = require('knex')({
+import knex from 'knex'
+const knexInstance = knex({
   client: 'mysql2',
   connection: {
     host: '127.0.0.1',
@@ -35,7 +36,7 @@ Let's extend the `/info` route to also respond with the MySQL version: `{ "nodeV
 
 ```js
 app.get('/info', async (req, res) => {
-  const [rows] = await knex.raw('SELECT VERSION()')
+  const [rows] = await knexInstance.raw('SELECT VERSION()')
 
   res.json({
     nodeVersion: process.version,

--- a/week1/lesson-plan.md
+++ b/week1/lesson-plan.md
@@ -48,7 +48,7 @@ In the first week of the module we will focus on a general introduction starting
   - [ ] npm init
   - [ ] Tests
   - [ ] Modules
-    - [ ] Creating and importing using `module.exports` and `require`
+    - [ ] Creating and importing using `export` and `import` in modern ES6 syntax
     - [ ] [Live coding](#created-module)
     - [ ] Npm modules
       - npmjs.org

--- a/week2/exercises/01-server.md
+++ b/week2/exercises/01-server.md
@@ -14,10 +14,12 @@ Initialize and install:
     $ npm init -y
     $ npm install express mysql2 knex
 
+Make sure you have `"type": "module"` in your `package.json`.
+
 Create a file named `app.js` and use the following as a starting point for this exercise:
 
 ```js
-const express = require("express")
+import express from 'express'
 const app = express()
 const port = process.env.PORT || 3000
 

--- a/week2/exercises/03-api.md
+++ b/week2/exercises/03-api.md
@@ -12,7 +12,7 @@ That will look something like this:
 ```js
 // Contents of api/snippets.js
 
-const express = require("express")
+import express from 'express'
 const router = express.Router()
 
 // GET /api/snippets
@@ -23,14 +23,16 @@ router.get("/", async (request, response) => {
 // TODO: POST /api/snippets
 // TODO: GET /api/snippets/:id
 
-module.exports = router
+export default router
 ```
 
 We will also have the database connection in a separate file:
 ```js
 // Contents of database.js
 
-const knex = require("knex")({
+import knex from 'knex'
+
+const knexInstance = knex({
   client: "mysql2",
   connection: {
     host: process.env.DB_HOST || "127.0.0.1",
@@ -41,7 +43,7 @@ const knex = require("knex")({
   },
 })
 
-module.exports = knex
+export default knexInstance
 ```
 
 At this point verify that your project structure looks like this:

--- a/week2/exercises/04-post-endpoint.md
+++ b/week2/exercises/04-post-endpoint.md
@@ -7,9 +7,10 @@ Let's start with a simplified version of the `POST /api/snippets` route. First w
 ```js
 // Contents of api/snippets.js
 
-const express = require("express")
+import express from 'express'
+import knexInstance from '../database.js'
+
 const router = express.Router()
-const knex = require("../database")
 
 // GET /api/snippets
 router.get("/", async (request, response) => {
@@ -23,7 +24,7 @@ router.post("/", async (request, response) => {
 
 // TODO: GET /api/snippets/:id
 
-module.exports = router
+export default router
 ```
 
 ---
@@ -45,7 +46,7 @@ But first, for Express to handle JSON requests, we need to add `app.use(express.
 ```js
 // Contents of app.js
 
-const express = require("express")
+import express from 'express'
 const app = express()
 const port = process.env.PORT || 3000
 
@@ -64,7 +65,8 @@ One remaining thing in the setup is to actually use the router we're exporting f
 Inside `app.js`, below `app.use(express.json())`, add the following:
 
 ```js
-app.use("/api/snippets", require("./api/snippets"))
+import snippetsRouter from "./api/snippets.js";
+app.use("/api/snippets", snippetsRouter)
 ```
 
 ---

--- a/week2/homework/readme.md
+++ b/week2/homework/readme.md
@@ -44,6 +44,8 @@ Go to `nodejs/week2` in your `hyf-homework` repo:
     $ npm i --save-dev nodemon
     $ npm set-script dev "nodemon app.js"
 
+Make sure you have `"type": "module"` in your `package.json`.
+
 You should also ensure that the `node_modules/` folder is ignored by Git:
 
     $ echo node_modules/ >> .gitignore
@@ -51,7 +53,7 @@ You should also ensure that the `node_modules/` folder is ignored by Git:
 Create `app.js` and as a starting point you can use the following code:
 
 ```js
-const express = require("express");
+import express from 'express'
 const app = express();
 const port = process.env.PORT || 3000;
 

--- a/week2/readme.md
+++ b/week2/readme.md
@@ -8,7 +8,7 @@ The most basic express webserver looks like the following
 ````
 // We require the express package after having installed it 
 // via “npm i express”
-const express = require('express')
+import express from 'express'
 
 // We create an express instance and bind it to our app const
 const app = express()

--- a/week3/homework/readme.md
+++ b/week3/homework/readme.md
@@ -33,6 +33,8 @@ Go to `nodejs/week3` in your `hyf-homework` repo:
     $ npm i --save-dev nodemon
     $ npm set-script dev "nodemon app.js"
 
+Make sure you have `"type": "module"` in your `package.json`.
+
 You should also ensure that the `node_modules/` folder is ignored by Git:
 
     $ echo node_modules/ >> .gitignore
@@ -80,7 +82,8 @@ insert into contacts (id, first_name, last_name, email, phone) values (25, 'Tabo
 Create `app.js`:
 
 ```js
-const knex = require("knex")({
+import knex from 'knex'
+const knexInstance = knex({
   client: "mysql2",
   connection: {
     host: process.env.DB_HOST || "127.0.0.1",
@@ -92,7 +95,7 @@ const knex = require("knex")({
   },
 });
 
-const express = require("express");
+import express from 'express'
 const app = express();
 const port = process.env.PORT || 3000;
 


### PR DESCRIPTION
Instead of using the classical way with commonjs, I'm switching the examples in the curriculum to use import/export as it's natively supported now in node.js with `"type": "module"` in `package.json`