### PR TITLE
Reference and adjust for new project template

### DIFF
--- a/week1/homework/readme.md
+++ b/week1/homework/readme.md
@@ -3,12 +3,18 @@
 This homework will result in 2 pull requests:
 
 - A pull request for the **Warmup** - in your regular hyf-homework repository
-- A pull request for the **Meal-sharing endpoints** - in the new meal-sharing repository
+- A pull request for the **meal sharing endpoints** - in a newly created meal-sharing repository
 
-### **Meal-sharing repository**
+### **meal-sharing repository**
 
-Go to [the meal-sharing-template repo](https://github.com/HackYourFuture-CPH/meal-sharing-template/generate) and create your own personal repo with the name `meal-sharing`. <br/>
-You should now have a meal-sharing repository here: `https://github.com/YOUR_GITHUB_USER_NAME/meal-sharing` like `https://github.com/benna100/meal-sharing`. Clone that repository down locally.
+Go to the [HYF project template repository](https://github.com/HackYourFuture-CPH/hyf-project-template) and click the "Use this template" button, then the "Create a new repository" option.  
+
+In the field `Repository name` fill in "meal-sharing", and mark the repository as "Public" before clicking "Create repository".  
+
+You should now have a new repository based on this template that you can clone to your local machine using:
+```
+git clone git@github.com:YOUR_GITHUB_USER_NAME/meal-sharing.git
+```
 
 #### Branch
 
@@ -41,25 +47,23 @@ Optional improvements and considerations:
 
 ## **Meal sharing endpoints**
 
-You will begin working in the meal-sharing repository for this homework and continue throughout the whole Node.js module. Each week you will build upon the endpoints, resulting in the backend setup for your future meal sharing website.
+You will begin working in the meal-sharing repository for this homework and continue throughout the whole Node.js module.  
+Each week you will extend the endpoints, resulting in the backend setup for your future meal sharing website.
 
 ### **Setup**
 
-The meal-sharing-template [README](https://github.com/HackYourFuture-CPH/meal-sharing-template#readme) has further instructions on how to set up and run this locally but the key steps are summarized here:
-
-- Run `npm install` to install all the needed NPM packages.
-- Create `.env` by copying the existing `.env.example` file. Update `DB_USER`, `DB_PASSWORD`, etc. so the server can successfully establish the connection to the database.
-- Run `npm run server` to start the server.
+Please follow the instructions in the [README.md](https://github.com/HackYourFuture-CPH/hyf-project-template/blob/main/README.md) in your meal-sharing repository to get your environment ready. You can ignore the "Deploying" section for now, you will come back to that in a few weeks.
 
 #### **Database**
 
 In the Database module, we worked on the meal sharing database. The diagram for that database can be found [here](https://dbdiagram.io/d/5f0460690425da461f045a29).
 
-In this homework, we will **reuse the same database** schema and build a web server with the following routes.
+In this homework, we will **reuse the same database** schema and build an API server with the below routes.
 
 #### **Getting started**
 
-The routes you need to implement as part of this homework should go into `/src/backend/app.js` after the line where it says `router.use("/meals", mealsRouter);`. There you can go ahead and define the desired routes like you normally would:
+The routes you need to implement as part of this homework should go into `/api/src/index.js`. 
+You can go ahead and define the desired routes like you normally would using the `app` variable:
 
 ```js
 app.get("/my-route", (req, res) => {
@@ -93,16 +97,9 @@ The other routes should in that case just return an empty array.
 Our usage of Knex will get more advanced over the coming weeks but for now, we will focus on the simplified `knex.raw` function that can execute a raw SQL query. Example:
 
 ```js
-knex.raw("SELECT VERSION()").then(() => {
-  console.log(`connection to db successful!`);
-});
+const meals = await knex.raw("SELECT * FROM Meal");
+console.log(meals);
 ```
-
-Note: `SELECT VERSION()` is a valid MySQL query but you would probably do something like this `SELECT * FROM some_table`.
-
-Also, `knex.raw` returns a Promise so you can also use the `async/await` syntax.
-
-<br/>
 
 ## Hand in homework
 

--- a/week2/homework/readme.md
+++ b/week2/homework/readme.md
@@ -3,7 +3,7 @@
 This homework, just like the previous week, will result in 2 pull requests:
 
 - A pull request for the **Warmup** - in your regular hyf-homework repository
-- A pull request for the additional **Meal-sharing endpoints** - in the meal-sharing repository
+- A pull request for the additional **Meal sharing endpoints** - in the meal-sharing repository
 
 In both repositories, create a `nodejs-week2` branch from `main` to work on the homework (`git checkout -b nodejs-week2` )
 
@@ -136,14 +136,17 @@ You will continue working in the meal-sharing repository for this homework. This
 
 ### **Routes**
 
-In last week's homework you were supposed to add routes in `src/backend/app.js`. You can just leave them there as they are.
+In last week's homework you were supposed to add routes in `/api/src/index.js`. You can just leave them there as they are.
 
 For this week's homework, we will add two categories of routes: meals and reservations.
 
-- The routes for meals will go into `src/backend/api/meals.js`, which should already exist in your repo, and
-- the reservation routes will live in `src/backend/api/reservations.js`, a new file you need to create.
+- The routes for meals will go into `/api/src/routers/meals.js`
+- the reservation routes will live in `/api/src/routers/reservations.js`
 
-This means that we will end up having 2 Routers: a meals router and a reservations router. You can read more about Express Routers [here](http://expressjs.com/en/4x/api.html#router).
+This means that we will end up having 2 Routers: a meals router and a reservations router.  
+You can read more about Express Routers [here](http://expressjs.com/en/4x/api.html#router).
+
+You can reference the file `/api/src/routers/nested.js` for an example, and see how it is used in `/api/src/index.js`.
 
 #### **Meals**
 
@@ -176,7 +179,7 @@ All the `POST` or `PUT` endpoints will require a request body - the information 
 All the specified `GET` routes should respond with JSON with the available columns from the associated tables.
 
 The `GET`, `PUT` and `DELETE` routes that include an `/:id` in the path should make sure to handle the case when the row with that ID does not exist.
-Think about what special HTTP status code would be appropriate for that scenario.
+> Think about what special HTTP status code would be appropriate for that scenario.
 
 You are free to decide on the response for a successful `POST`, `PUT` and `DELETE` request. Some ideas:
 
@@ -184,8 +187,6 @@ You are free to decide on the response for a successful `POST`, `PUT` and `DELET
 - Respond with data from the row itself like with `GET`
 
 And lastly, if the `POST` request is successful, the response status code should be 201 Created, as that would indicate something was _created_.
-
-<br/>
 
 #### **Knex**
 
@@ -198,9 +199,7 @@ Your usage of Knex should be getting a bit more advanced now. You will move from
 
 Check out the [Knex cheatsheet](https://devhints.io/knex)!
 
-<br/>
-
 ## Hand in homework
 
-Need to brush up on the homework hand-in process?<br/>
+Need to brush up on the homework hand-in process?  
 Check [this resource](https://github.com/HackYourFuture-CPH/Git/blob/main/homework-submission.md) to remember how to hand in the homework correctly!

--- a/week3/homework/readme.md
+++ b/week3/homework/readme.md
@@ -3,7 +3,7 @@
 Once again, you will deliver 2 pull requests:
 
 - A pull request for the **Warmup** - in your regular hyf-homework repository
-- A pull request for the additional **Meal-sharing endpoints** - in the meal-sharing repository
+- A pull request for the additional **meal sharing endpoints** - in the meal-sharing repository
 
 In both repositories, create a `nodejs-week3` branch from `main` to work on the homework (`git checkout -b nodejs-week3` ).
 
@@ -146,14 +146,16 @@ After having demonstrated the SQL injection vulnerability, the goal is then to f
 
 ## **Meal sharing endpoints**
 
-You will continue working in the meal-sharing repository for this task.
-<br/>You should have the basic [CRUD](https://www.freecodecamp.org/news/crud-operations-explained/) endpoints for **meals** and **reservations** as the result of last week's homework. This week, you will add **query parameters**, that will allow you to **sort** and **filter** the information retrieved from the database.
+You will continue working in the meal-sharing repository for this task.  
+
+You should have the basic [CRUD](https://www.freecodecamp.org/news/crud-operations-explained/) endpoints for **meals** and **reservations** as the result of last week's homework. This week, you will add **query parameters**, that will allow you to **sort** and **filter** the information retrieved from the database.
 
 ### **Routes**
 
 #### **Meals**
 
-Work with your `GET api/meals` route to add the query parameters. <br/>Make sure that the query parameters can be combined, f.x. <nobr>`?limit=4&maxPrice=90`.<nobr/>
+Work with your `GET api/meals` route to add the query parameters.  
+Make sure that the query parameters can be combined, f.x. <nobr>`?limit=4&maxPrice=90`.<nobr/>
 
 | Parameter               | <nobr>Data type<nobr/> | Description                                                                                                                             | Example                                             |
 | ----------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
@@ -170,8 +172,6 @@ Work with your `GET api/meals` route to add the query parameters. <br/>Make sure
 [^2]: This used to be `sort_key` in a previous version of the homework text.
 [^3]: This used to be `sort_dir` in a previous version of the homework text.
 
-<br/>
-
 #### **Reviews**
 
 By now, you have the basic set of endpoints for **meals** and **reservations** and even a collection of query parameters for **meals**. To practice a bit more and finalize the basic backend functionality, create the set of routes for **reviews**:
@@ -185,8 +185,6 @@ By now, you have the basic set of endpoints for **meals** and **reservations** a
 | `/api/reviews/:id`            | PUT         | Updates the review by `id`.              |
 | `/api/reviews/:id`            | DELETE      | Deletes the review by `id`.              |
 
-<br/>
-
 #### **Knex**
 
 You should try to avoid using `knex.raw` and instead use the different `knex` functions, for example:
@@ -197,8 +195,6 @@ You should try to avoid using `knex.raw` and instead use the different `knex` fu
 - `.del` (for deletion)
 
 Check out the [Knex cheatsheet](https://devhints.io/knex)!
-
-<br/>
 
 ## Hand in homework
 


### PR DESCRIPTION
With the introduction of https://github.com/HackYourFuture-CPH/hyf-project-template, we're deprecating the old meal-sharing-template. 
This PR replaces all references and instructions related to the old template with instructions for the new template.
The goal is to have a template that is easier for students to use since it is up to date and follows a simpler model.