### PR TITLE
Replace npm deprecated command

### DIFF
--- a/week1/exercises/01-server.md
+++ b/week1/exercises/01-server.md
@@ -12,12 +12,15 @@ You can also reuse some other folder. Main thing to watch out for is that the fo
 Initialize and install:
 
     $ npm init -y
+    $ npm pkg set type="module"
     $ npm install express
+    $ echo node_modules/ >> .gitignore
 
 Make sure you see a `package.json`.
 Make sure you have `"type": "module"` in your `package.json`.
 Do you see `express` somewhere in `package.json`?
-Also make sure you see the `node_modules` folder.
+Make sure you see the `node_modules` folder.
+Also make sure that the `node_modules/` folder is ignored by Git.
 
 ---
 

--- a/week1/exercises/03-user-routes.md
+++ b/week1/exercises/03-user-routes.md
@@ -16,7 +16,7 @@ Also, it is recommended to add a script to `package.json`, like so:
 
 There is a command to do that:
 
-    $ npm set-script dev "nodemon app.js"
+    $ npm pkg set scripts.dev="nodemon app.js"
 
 Now you can run
 

--- a/week2/exercises/01-server.md
+++ b/week2/exercises/01-server.md
@@ -12,9 +12,9 @@ You can also reuse some other folder. Main thing to watch out for is that the fo
 Initialize and install:
 
     $ npm init -y
+    $ npm pkg set type="module"
     $ npm install express mysql2 knex
-
-Make sure you have `"type": "module"` in your `package.json`.
+    $ echo node_modules/ >> .gitignore
 
 Create a file named `app.js` and use the following as a starting point for this exercise:
 
@@ -35,7 +35,7 @@ app.listen(port, () => {
 ---
 
     $ npm install --save-dev nodemon
-    $ npm set-script dev "nodemon app.js"
+    $ npm pkg set scripts.dev="nodemon app.js"
     $ npm run dev
 
 Go to http://localhost:3000 in your browser to verify that the server started.

--- a/week2/homework/readme.md
+++ b/week2/homework/readme.md
@@ -40,13 +40,12 @@ The purpose of the search engine is to search and find documents from a file cal
 Go to `nodejs/week2` in your `hyf-homework` repo:
 
     $ npm init -y
+    $ npm pkg set type="module"
     $ npm i express
     $ npm i --save-dev nodemon
-    $ npm set-script dev "nodemon app.js"
+    $ npm pkg set scripts.dev="nodemon app.js"
 
-Make sure you have `"type": "module"` in your `package.json`.
-
-You should also ensure that the `node_modules/` folder is ignored by Git:
+You should ensure that the `node_modules/` folder is ignored by Git:
 
     $ echo node_modules/ >> .gitignore
 


### PR DESCRIPTION
The `npm set-script` is deprecated and no longer works, which causes friction during classes. Replaced it with the new `npm pkg set scripts` API.

Also, instead of manually adding `"type": "module"` to `package.json`, we can leverage the `npm pkg set` API to create the dev script.